### PR TITLE
Fix formatting for "username <email>" in cabal file

### DIFF
--- a/package-name/package-name.cabal.template
+++ b/package-name/package-name.cabal.template
@@ -1,7 +1,7 @@
 Name:                   $packageName
 Version:                0.0.0
-Author:                 $author<$email>
-Maintainer:             $author<$email>
+Author:                 $author <$email>
+Maintainer:             $author <$email>
 License:                BSD3
 License-File:           LICENSE
 -- Synopsis:               


### PR DESCRIPTION
Added a space between $author and <$email> in Author and Maintainer
directives in cabal file.

$author and <$email> generally have a space between them.  For example,
git commit message, email messages, the hashable library's cabal file,
and the lens library's cabal file.
